### PR TITLE
Remove previous axis on axis redraw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# IntelliJ IDE
+.idea

--- a/src/axis/axis.js
+++ b/src/axis/axis.js
@@ -43,15 +43,12 @@ const setAxis = axes => {
 export function axisTop(scales) {
     return setAxis(scales.mapScales(scale => d3Axis.axisTop(scale)));
 }
-
 export function axisRight(scales) {
     return setAxis(scales.mapScales(scale => d3Axis.axisRight(scale)));
 }
-
 export function axisBottom(scales) {
     return setAxis(scales.mapScales(scale => d3Axis.axisBottom(scale)));
 }
-
 export function axisLeft(scales) {
     return setAxis(scales.mapScales(scale => d3Axis.axisLeft(scale)));
 }

--- a/src/axis/axis.js
+++ b/src/axis/axis.js
@@ -11,6 +11,7 @@ const setAxis = axes => {
     }
 
     function dispatch(context) {
+        context.selectAll('g').remove()
         axes.forEach((axis, idx) => context
             .append('g')
             .attr('class', `axis-${idx}`)
@@ -36,21 +37,21 @@ const setAxis = axes => {
         tickSizeOuter: arg => updateOrReturn('tickSizeOuter', parseArg(arg, axes.length)),
         tickPadding: arg => updateOrReturn('tickPadding', parseArg(arg, axes.length)),
     });
-    
+
 };
 
 export function axisTop(scales) {
     return setAxis(scales.mapScales(scale => d3Axis.axisTop(scale)));
 }
-  
+
 export function axisRight(scales) {
     return setAxis(scales.mapScales(scale => d3Axis.axisRight(scale)));
 }
-  
+
 export function axisBottom(scales) {
     return setAxis(scales.mapScales(scale => d3Axis.axisBottom(scale)));
 }
-  
+
 export function axisLeft(scales) {
     return setAxis(scales.mapScales(scale => d3Axis.axisLeft(scale)));
 }

--- a/src/axis/axis.js
+++ b/src/axis/axis.js
@@ -43,12 +43,15 @@ const setAxis = axes => {
 export function axisTop(scales) {
     return setAxis(scales.mapScales(scale => d3Axis.axisTop(scale)));
 }
+
 export function axisRight(scales) {
     return setAxis(scales.mapScales(scale => d3Axis.axisRight(scale)));
 }
+
 export function axisBottom(scales) {
     return setAxis(scales.mapScales(scale => d3Axis.axisBottom(scale)));
 }
+
 export function axisLeft(scales) {
     return setAxis(scales.mapScales(scale => d3Axis.axisLeft(scale)));
 }


### PR DESCRIPTION
When you needed to redraw an axis (for example, the domain changes because the user deselects one dataset or the axis scale changes, axis.js added 2 new axes without removing previous generating a visualization bug

![image](https://user-images.githubusercontent.com/1263666/100865143-41963080-3497-11eb-91c8-7a7ca940b529.png)
